### PR TITLE
[feat] : JPA 엔티티 매핑, Config 설정

### DIFF
--- a/sunpick/build.gradle
+++ b/sunpick/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+	implementation 'mysql:mysql-connector-java:8.0.33'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/sunpick/src/main/java/com/backend/sunpick/SunpickApplication.java
+++ b/sunpick/src/main/java/com/backend/sunpick/SunpickApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class SunpickApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SunpickApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(SunpickApplication.class, args);
+    }
 
 }

--- a/sunpick/src/main/java/com/backend/sunpick/config/JpaConfig.java
+++ b/sunpick/src/main/java/com/backend/sunpick/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/entity/Coupon.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/entity/Coupon.java
@@ -1,0 +1,51 @@
+package com.backend.sunpick.domain.coupon.entity;
+
+import com.backend.sunpick.domain.coupon.enums.DiscountType;
+import com.backend.sunpick.domain.coupon.enums.DiscountTypeConverter;
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "coupon")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "issuer_id", nullable = false)
+    private CouponIssuer couponIssuer;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "valid_days", nullable = false)
+    private Integer validDays;
+
+    @Column(name = "discount_weight", nullable = false)
+    private Integer discountWeight;
+
+    @Convert(converter = DiscountTypeConverter.class)
+    @Column(name = "discount_type", nullable = false)
+    private DiscountType discountType;
+}
+
+
+

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/entity/CouponIssuer.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/entity/CouponIssuer.java
@@ -1,0 +1,33 @@
+package com.backend.sunpick.domain.coupon.entity;
+
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "coupon_issuer")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponIssuer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+}
+
+

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/entity/ProvidedCoupon.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/entity/ProvidedCoupon.java
@@ -1,0 +1,46 @@
+package com.backend.sunpick.domain.coupon.entity;
+
+import com.backend.sunpick.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity
+@Table(name = "provided_coupon")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProvidedCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Column(name = "used_date", nullable = false)
+    private Date usedDate;
+
+    @Column(name = "expired_date", nullable = false)
+    private Date expiredDate;
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/enums/DiscountType.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/enums/DiscountType.java
@@ -1,0 +1,25 @@
+package com.backend.sunpick.domain.coupon.enums;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public enum DiscountType {
+    PIXED(1),
+    PERCENT(2);
+
+    private Integer code;
+
+    DiscountType(Integer code) {
+        this.code = code;
+    }
+
+    public static DiscountType ofLegacyCode(Integer code){
+        for (DiscountType type : DiscountType.values()) {
+            if(Objects.equals(type.getCode(), code)){
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("입력된 할인타입 코드번호가 존재하지않습니다.");
+    }
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/enums/DiscountTypeConverter.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/enums/DiscountTypeConverter.java
@@ -1,0 +1,23 @@
+package com.backend.sunpick.domain.coupon.enums;
+
+import jakarta.persistence.AttributeConverter;
+import java.util.Objects;
+
+public class DiscountTypeConverter implements AttributeConverter<DiscountType, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(DiscountType discountType) {
+        if(!Objects.isNull(discountType)){
+            return discountType.getCode();
+        }
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public DiscountType convertToEntityAttribute(Integer code) {
+        if(!Objects.isNull(code)){
+            return DiscountType.ofLegacyCode(code);
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/repository/CouponIssuerRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/repository/CouponIssuerRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.coupon.repository;
+
+import com.backend.sunpick.domain.coupon.entity.CouponIssuer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CouponIssuerRepository extends JpaRepository<CouponIssuer, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/repository/CouponRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/repository/CouponRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.coupon.repository;
+
+import com.backend.sunpick.domain.coupon.entity.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CouponRepository extends JpaRepository<Coupon, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/coupon/repository/ProvidedCouponRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/coupon/repository/ProvidedCouponRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.coupon.repository;
+
+import com.backend.sunpick.domain.coupon.entity.ProvidedCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProvidedCouponRepository extends JpaRepository<ProvidedCoupon, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/entity/ExclusiveProduct.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/entity/ExclusiveProduct.java
@@ -1,0 +1,43 @@
+package com.backend.sunpick.domain.exclusive.entity;
+
+import com.backend.sunpick.domain.store.entity.Store;
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "exclusive_product")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExclusiveProduct extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/entity/ExclusiveSaleEvent.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/entity/ExclusiveSaleEvent.java
@@ -1,0 +1,52 @@
+package com.backend.sunpick.domain.exclusive.entity;
+
+import com.backend.sunpick.domain.store.entity.Store;
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "exclusive_sale_event")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExclusiveSaleEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "exclusive_product_id", nullable = false)
+    private ExclusiveProduct exclusiveProduct;
+
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "open_at", nullable = false)
+    private LocalDateTime openAt;
+
+    @Column(name = "close_at", nullable = false)
+    private LocalDateTime closeAt;
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/repository/ExclusiveProductRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/repository/ExclusiveProductRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.exclusive.repository;
+
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExclusiveProductRepository extends JpaRepository<ExclusiveProduct, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/repository/ExclusiveSaleEventRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/exclusive/repository/ExclusiveSaleEventRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.exclusive.repository;
+
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveSaleEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExclusiveSaleEventRepository extends JpaRepository<ExclusiveSaleEvent, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/member/entity/Member.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/member/entity/Member.java
@@ -1,0 +1,42 @@
+package com.backend.sunpick.domain.member.entity;
+
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "member")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "name", length = 6, nullable = false)
+    private String name;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", length = 15, nullable = false)
+    private String password;
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(name = "withdrawn_at", nullable = false)
+    private LocalDateTime withdrawnAt;
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/member/repository/MemberRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.member.repository;
+
+import com.backend.sunpick.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/point/entity/SunpickPointHistory.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/point/entity/SunpickPointHistory.java
@@ -1,0 +1,37 @@
+package com.backend.sunpick.domain.point.entity;
+
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "sunpick_point_history")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SunpickPointHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "change_point", nullable = false)
+    private Integer changePoint;
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/point/repository/SunpickPointHistoryRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/point/repository/SunpickPointHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.point.repository;
+
+import com.backend.sunpick.domain.point.entity.SunpickPointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SunpickPointHistoryRepository extends JpaRepository<SunpickPointHistory, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/purchase/entity/PurchaseHistory.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/purchase/entity/PurchaseHistory.java
@@ -1,0 +1,61 @@
+package com.backend.sunpick.domain.purchase.entity;
+
+import com.backend.sunpick.domain.coupon.entity.Coupon;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveProduct;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveSaleEvent;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.point.entity.SunpickPointHistory;
+import com.backend.sunpick.domain.purchase.enums.PurchaseType;
+import com.backend.sunpick.domain.purchase.enums.PurchaseTypeConverter;
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "purchase_history")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PurchaseHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "used_coupon_id")
+    private Coupon coupon;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "exclusive_sale_event_id", nullable = false)
+    private ExclusiveSaleEvent exclusiveSaleEvent;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sunpic_point_history_id")
+    private SunpickPointHistory sunpickPointHistory;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Convert(converter = PurchaseTypeConverter.class)
+    @Column(name = "purchase_type", nullable = false)
+    private PurchaseType purchaseType;
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/purchase/enums/PurchaseType.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/purchase/enums/PurchaseType.java
@@ -1,0 +1,27 @@
+package com.backend.sunpick.domain.purchase.enums;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public enum PurchaseType {
+
+    CARD(1),
+    POINT(2),
+    TOSSPAY(3);
+
+    private Integer code;
+
+    PurchaseType(Integer code) {
+        this.code = code;
+    }
+
+    public static PurchaseType ofLegacyCode(Integer code) {
+        for (PurchaseType type : PurchaseType.values()) {
+            if (Objects.equals(type.getCode(), code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 구매방식입니다.");
+    }
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/purchase/enums/PurchaseTypeConverter.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/purchase/enums/PurchaseTypeConverter.java
@@ -1,0 +1,23 @@
+package com.backend.sunpick.domain.purchase.enums;
+
+import jakarta.persistence.AttributeConverter;
+import java.util.Objects;
+
+public class PurchaseTypeConverter implements AttributeConverter<PurchaseType, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(PurchaseType purchaseType) {
+        if(!Objects.isNull(purchaseType)){
+            return purchaseType.getCode();
+        }
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public PurchaseType convertToEntityAttribute(Integer code) {
+        if(!Objects.isNull(code)){
+            return PurchaseType.ofLegacyCode(code);
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/purchase/repository/PurchaseHistoryRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/purchase/repository/PurchaseHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.purchase.repository;
+
+import com.backend.sunpick.domain.purchase.entity.PurchaseHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PurchaseHistoryRepository extends JpaRepository<PurchaseHistory, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/store/entity/Store.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/store/entity/Store.java
@@ -1,0 +1,43 @@
+package com.backend.sunpick.domain.store.entity;
+
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "store")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @Column(name = "description", length = 100)
+    private String description;
+
+    @Column(name = "owner_name", length = 6, nullable = false)
+    private String ownerName;
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/domain/store/repository/StoreRepository.java
+++ b/sunpick/src/main/java/com/backend/sunpick/domain/store/repository/StoreRepository.java
@@ -1,0 +1,10 @@
+package com.backend.sunpick.domain.store.repository;
+
+import com.backend.sunpick.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Integer> {
+
+}

--- a/sunpick/src/main/java/com/backend/sunpick/global/common/entity/BaseEntity.java
+++ b/sunpick/src/main/java/com/backend/sunpick/global/common/entity/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.backend.sunpick.global.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+}


### PR DESCRIPTION
## 🗂️ 작업 개요
JPA Entity 매핑작업 및 설정관리

## 🛠️ 주요 변경 사항

- Coupon, CouponIssuer, ProvidedCoupon, Member, SunpickPointHistory,
   PurchaseHistory, Store, ExclusiveProduct, ExclusiveSaleEvent,BaseEntity 작성

- JpaConfig, .properties 작성

## 🧪 테스트
- Build 성공 및 정상 작동

## 📌 참고 사항
- Junit 테스트코드 작성을 진행할 예정입니다
