### PR TITLE
[feat] 전체 도메인 엔티티 JPA 매핑 테스트코드 작성

### DIFF
--- a/sunpick/src/test/java/com/backend/sunpick/coupon/CouponIssuerJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/coupon/CouponIssuerJpaMappingTest.java
@@ -1,0 +1,51 @@
+package com.backend.sunpick.coupon;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.coupon.entity.CouponIssuer;
+import com.backend.sunpick.domain.coupon.repository.CouponIssuerRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class CouponIssuerJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private CouponIssuerRepository issuerRepository;
+
+    @Test
+    void 쿠폰발행자_엔티티_필드_매핑_정상작동_테스트() {
+
+        // given
+        CouponIssuer couponIssuer = TestEntityFactory.testCouponIssuer();
+        CouponIssuer savedCouponIssuer = issuerRepository.save(couponIssuer);
+        em.flush();
+        em.clear();
+
+        // when
+        CouponIssuer selectedCouponIssuer = issuerRepository.findById(savedCouponIssuer.getId())
+            .orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedCouponIssuer.getName()).isEqualTo("SunPick");
+            as.assertThat(selectedCouponIssuer.getQuantity()).isEqualTo(1000);
+            as.assertThat(selectedCouponIssuer.getCreatedAt()).isNotNull();
+            as.assertThat(selectedCouponIssuer.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/coupon/CouponJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/coupon/CouponJpaMappingTest.java
@@ -1,0 +1,61 @@
+package com.backend.sunpick.coupon;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.coupon.entity.Coupon;
+import com.backend.sunpick.domain.coupon.entity.CouponIssuer;
+import com.backend.sunpick.domain.coupon.enums.DiscountType;
+import com.backend.sunpick.domain.coupon.repository.CouponIssuerRepository;
+import com.backend.sunpick.domain.coupon.repository.CouponRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class CouponJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponIssuerRepository issuerRepository;
+
+    @Test
+    void 쿠폰_엔티티_필드_및_연관관계_매핑_정상작동_테스트() {
+
+        // given
+        CouponIssuer couponIssuer = TestEntityFactory.testCouponIssuer();
+        CouponIssuer savedCouponIssuer = issuerRepository.save(couponIssuer);
+        Coupon coupon = TestEntityFactory.testCoupon(savedCouponIssuer);
+        Coupon savedCoupon = couponRepository.save(coupon);
+        em.flush();
+        em.clear();
+
+        // when
+        Coupon selectedCoupon = couponRepository.findById(savedCoupon.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedCoupon.getCouponIssuer().getId()).isEqualTo(savedCouponIssuer.getId());
+            as.assertThat(selectedCoupon.getName()).isEqualTo("선픽 개봉기념 할인쿠폰");
+            as.assertThat(selectedCoupon.getValidDays()).isEqualTo(31);
+            as.assertThat(selectedCoupon.getDiscountType()).isEqualTo(DiscountType.PIXED);
+            as.assertThat(selectedCoupon.getDiscountWeight()).isEqualTo(1000);
+            as.assertThat(selectedCoupon.getCreatedAt()).isNotNull();
+            as.assertThat(selectedCoupon.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/coupon/ProvidedCouponJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/coupon/ProvidedCouponJpaMappingTest.java
@@ -1,0 +1,84 @@
+package com.backend.sunpick.coupon;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.coupon.entity.Coupon;
+import com.backend.sunpick.domain.coupon.entity.CouponIssuer;
+import com.backend.sunpick.domain.coupon.entity.ProvidedCoupon;
+import com.backend.sunpick.domain.coupon.repository.CouponIssuerRepository;
+import com.backend.sunpick.domain.coupon.repository.CouponRepository;
+import com.backend.sunpick.domain.coupon.repository.ProvidedCouponRepository;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class ProvidedCouponJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private ProvidedCouponRepository providedCouponRepository;
+
+    @Autowired
+    private CouponIssuerRepository issuerRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+
+    @Test
+    void 제공된쿠폰_엔티티_필드_및_연관관계_정상작동_테스트() {
+
+        // given
+        Member member = TestEntityFactory.testMember();
+        Member savedMember = memberRepository.save(member);
+        CouponIssuer couponIssuer = TestEntityFactory.testCouponIssuer();
+        CouponIssuer savedCouponIssuer = issuerRepository.save(couponIssuer);
+        Coupon coupon = TestEntityFactory.testCoupon(savedCouponIssuer);
+        Coupon savedCoupon = couponRepository.save(coupon);
+
+        ProvidedCoupon providedCoupon = TestEntityFactory
+            .testProvidedCoupon(savedMember, savedCoupon);
+        ProvidedCoupon savedProvidedCoupon = providedCouponRepository.save(providedCoupon);
+        em.flush();
+        em.clear();
+
+        // when
+        ProvidedCoupon selectedProvidedCoupon = providedCouponRepository.findById(
+            savedProvidedCoupon.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedProvidedCoupon.getMember().getId())
+                .isEqualTo(savedMember.getId());
+            as.assertThat(selectedProvidedCoupon.getCoupon().getId())
+                .isEqualTo(savedCoupon.getId());
+            as.assertThat(selectedProvidedCoupon.getCoupon().getCouponIssuer().getId())
+                .isEqualTo(savedCouponIssuer.getId());
+            as.assertThat(selectedProvidedCoupon.getUsedDate()).isNull();
+            as.assertThat(selectedProvidedCoupon.getExpiredDate())
+                .isEqualTo(LocalDate.of(2025, 8, 15));
+            as.assertThat(selectedProvidedCoupon.getCreatedAt()).isNotNull();
+            as.assertThat(selectedProvidedCoupon.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/exclusive/ExclusiveProductJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/exclusive/ExclusiveProductJpaMappingTest.java
@@ -1,0 +1,72 @@
+package com.backend.sunpick.exclusive;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveProduct;
+import com.backend.sunpick.domain.exclusive.repository.ExclusiveProductRepository;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.domain.store.entity.Store;
+import com.backend.sunpick.domain.store.repository.StoreRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class ExclusiveProductJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private ExclusiveProductRepository productRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Test
+    void 한정판상품_엔티티_필드_및_연관관계_정상작동_테스트() {
+
+        // given
+        Member member = TestEntityFactory.testMember();
+        Member savedMember = memberRepository.save(member);
+
+        Store store = TestEntityFactory.testStore(savedMember);
+        Store savedStore = storeRepository.save(store);
+
+        ExclusiveProduct exclusiveProduct = TestEntityFactory.testExclusiveProduct(savedStore);
+        ExclusiveProduct savedExclusiveProduct = productRepository.save(exclusiveProduct);
+        em.flush();
+        em.clear();
+
+        // when
+        ExclusiveProduct selectedExclusiveProduct = productRepository.findById(
+            savedExclusiveProduct.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedExclusiveProduct.getStore().getId())
+                .isEqualTo(savedStore.getId());
+            as.assertThat(selectedExclusiveProduct.getStore().getMember().getId())
+                .isEqualTo(savedMember.getId());
+            as.assertThat(selectedExclusiveProduct.getName()).isEqualTo("주먹밥");
+            as.assertThat(selectedExclusiveProduct.getPrice()).isEqualTo(2000);
+            as.assertThat(selectedExclusiveProduct.getQuantity()).isEqualTo(1000);
+            as.assertThat(selectedExclusiveProduct.getCreatedAt()).isNotNull();
+            as.assertThat(selectedExclusiveProduct.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/exclusive/ExclusiveSaleEventJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/exclusive/ExclusiveSaleEventJpaMappingTest.java
@@ -1,0 +1,82 @@
+package com.backend.sunpick.exclusive;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveProduct;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveSaleEvent;
+import com.backend.sunpick.domain.exclusive.repository.ExclusiveProductRepository;
+import com.backend.sunpick.domain.exclusive.repository.ExclusiveSaleEventRepository;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.domain.store.entity.Store;
+import com.backend.sunpick.domain.store.repository.StoreRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class ExclusiveSaleEventJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private ExclusiveSaleEventRepository eventRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private ExclusiveProductRepository productRepository;
+
+    @Test
+    void 한정수량판매이벤트_엔티티_필드_및_연관관계_정상작동_테스트() {
+
+        // given
+        Member savedMember = memberRepository.save(TestEntityFactory.testMember());
+        Store savedStore = storeRepository.save(TestEntityFactory.testStore(savedMember));
+        ExclusiveProduct savedExclusiveProduct = productRepository.save(
+            TestEntityFactory.testExclusiveProduct(savedStore));
+
+        ExclusiveSaleEvent exclusiveSaleEvent = TestEntityFactory
+            .testExclusiveSaleEvent(savedStore, savedExclusiveProduct);
+        ExclusiveSaleEvent savedExclusiveSaleEvent = eventRepository.save(exclusiveSaleEvent);
+        em.flush();
+        em.clear();
+
+        // when
+        ExclusiveSaleEvent selectedExclusiveSaleEvent = eventRepository.findById(
+            savedExclusiveSaleEvent.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedExclusiveSaleEvent.getStore().getId())
+                .isEqualTo(savedStore.getId());
+            as.assertThat(selectedExclusiveSaleEvent.getExclusiveProduct().getId())
+                .isEqualTo(savedExclusiveProduct.getId());
+            as.assertThat(selectedExclusiveSaleEvent.getName()).isEqualTo("오픈기념 주먹밥 한정판매");
+            as.assertThat(selectedExclusiveSaleEvent.getDescription()).isEqualTo("주먹밥 맛있어요 드셔보세요~");
+            as.assertThat(selectedExclusiveSaleEvent.getOpenAt())
+                .isEqualTo(LocalDateTime.of(2025, 8, 15, 12, 30));
+            as.assertThat(selectedExclusiveSaleEvent.getCloseAt())
+                .isEqualTo(LocalDateTime.of(2025, 9, 15, 12, 30));
+            as.assertThat(selectedExclusiveSaleEvent.getCreatedAt()).isNotNull();
+            as.assertThat(selectedExclusiveSaleEvent.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/factory/TestEntityFactory.java
+++ b/sunpick/src/test/java/com/backend/sunpick/factory/TestEntityFactory.java
@@ -1,0 +1,105 @@
+package com.backend.sunpick.factory;
+
+import com.backend.sunpick.domain.coupon.entity.Coupon;
+import com.backend.sunpick.domain.coupon.entity.CouponIssuer;
+import com.backend.sunpick.domain.coupon.entity.ProvidedCoupon;
+import com.backend.sunpick.domain.coupon.enums.DiscountType;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveProduct;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveSaleEvent;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.point.entity.SunpickPointHistory;
+import com.backend.sunpick.domain.purchase.entity.PurchaseHistory;
+import com.backend.sunpick.domain.purchase.enums.PurchaseType;
+import com.backend.sunpick.domain.store.entity.Store;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class TestEntityFactory {
+
+    public static Member testMember() {
+        return Member.builder()
+            .name("이영석")
+            .email("ssafy@naver.com")
+            .password("password123")
+            .birthDate(LocalDate.of(1999, 1, 15))
+            .withdrawnAt(null)
+            .build();
+    }
+
+    public static Store testStore(Member member) {
+        return Store.builder()
+            .name("선픽마켓")
+            .member(member)
+            .description("선픽마켓에 오신것을 환영합니다")
+            .ownerName("이영석")
+            .build();
+    }
+
+    public static Coupon testCoupon(CouponIssuer couponIssuer) {
+        return Coupon.builder()
+            .name("선픽 개봉기념 할인쿠폰")
+            .couponIssuer(couponIssuer)
+            .discountType(DiscountType.PIXED)
+            .discountWeight(1000)
+            .validDays(31)
+            .build();
+    }
+
+    public static CouponIssuer testCouponIssuer() {
+        return CouponIssuer.builder()
+            .name("SunPick")
+            .quantity(1000)
+            .build();
+    }
+
+    public static ProvidedCoupon testProvidedCoupon(Member member, Coupon coupon) {
+        return ProvidedCoupon.builder()
+            .member(member)
+            .coupon(coupon)
+            .usedDate(null)
+            .expiredDate(LocalDate.of(2025, 8, 15))
+            .build();
+    }
+
+    public static ExclusiveProduct testExclusiveProduct(Store store) {
+        return ExclusiveProduct.builder()
+            .store(store)
+            .name("주먹밥")
+            .price(2000)
+            .quantity(1000)
+            .build();
+    }
+
+    public static ExclusiveSaleEvent testExclusiveSaleEvent(Store store,
+        ExclusiveProduct exclusiveProduct) {
+        return ExclusiveSaleEvent.builder()
+            .store(store)
+            .exclusiveProduct(exclusiveProduct)
+            .name("오픈기념 주먹밥 한정판매")
+            .description("주먹밥 맛있어요 드셔보세요~")
+            .openAt(LocalDateTime.of(2025, 8, 15, 12, 30))
+            .closeAt(LocalDateTime.of(2025, 9, 15, 12, 30))
+            .build();
+    }
+
+    public static SunpickPointHistory testSunpickPointHistory(Member member){
+        return SunpickPointHistory.builder()
+            .member(member)
+            .changePoint(-10000)
+            .build();
+    }
+
+    public static PurchaseHistory testPurchaseHistory(Member member, Coupon coupon,
+        ExclusiveSaleEvent exclusiveSaleEvent, SunpickPointHistory sunpickPointHistory) {
+        return PurchaseHistory.builder()
+            .member(member)
+            .coupon(coupon)
+            .exclusiveSaleEvent(exclusiveSaleEvent)
+            .sunpickPointHistory(sunpickPointHistory)
+            .price(20000)
+            .purchaseType(PurchaseType.CARD)
+            .build();
+    }
+
+}

--- a/sunpick/src/test/java/com/backend/sunpick/member/MemberJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/member/MemberJpaMappingTest.java
@@ -1,0 +1,55 @@
+package com.backend.sunpick.member;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class MemberJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 멤버_엔티티_필드_매핑_정상작동_테스트() {
+
+        //given
+        Member member = TestEntityFactory.testMember();
+        Member savedMember = memberRepository.save(member);
+        em.flush();
+        em.clear();
+
+        //when
+        Member selectedMember = memberRepository.findById(savedMember.getId()).orElseThrow();
+
+        //then
+        assertSoftly(as -> {
+            as.assertThat(selectedMember.getName()).isEqualTo("이영석");
+            as.assertThat(selectedMember.getEmail()).isEqualTo("ssafy@naver.com");
+            as.assertThat(selectedMember.getPassword()).isEqualTo("password123");
+            as.assertThat(selectedMember.getBirthDate()).isEqualTo(LocalDate.of(1999, 1, 15));
+            as.assertThat(selectedMember.getWithdrawnAt()).isNull();
+            as.assertThat(selectedMember.getCreatedAt()).isNotNull();
+            as.assertThat(selectedMember.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/point/SunpickPointHistoryJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/point/SunpickPointHistoryJpaMappingTest.java
@@ -1,0 +1,62 @@
+package com.backend.sunpick.point;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.domain.point.entity.SunpickPointHistory;
+import com.backend.sunpick.domain.point.repository.SunpickPointHistoryRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class SunpickPointHistoryJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private SunpickPointHistoryRepository pointHistoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 선픽포인트내역_엔티티_필드_및_연관관계_매핑_정상작동_테스트() {
+
+        // given
+        Member member = TestEntityFactory.testMember();
+        Member savedMember = memberRepository.save(member);
+
+        SunpickPointHistory sunpickPointHistory = TestEntityFactory
+            .testSunpickPointHistory(savedMember);
+        SunpickPointHistory savedPointHistory = pointHistoryRepository.save(sunpickPointHistory);
+        em.flush();
+        em.clear();
+
+        // when
+        SunpickPointHistory selectedPointHistory = pointHistoryRepository
+            .findById(savedPointHistory.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedPointHistory.getMember().getId())
+                .isEqualTo(savedPointHistory.getMember().getId());
+            as.assertThat(selectedPointHistory.getChangePoint())
+                .isEqualTo(-10000);
+            as.assertThat(selectedPointHistory.getCreatedAt()).isNotNull();
+            as.assertThat(selectedPointHistory.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/purchase/PurchaseHistoryJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/purchase/PurchaseHistoryJpaMappingTest.java
@@ -1,0 +1,111 @@
+package com.backend.sunpick.purchase;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.coupon.entity.Coupon;
+import com.backend.sunpick.domain.coupon.entity.CouponIssuer;
+import com.backend.sunpick.domain.coupon.repository.CouponIssuerRepository;
+import com.backend.sunpick.domain.coupon.repository.CouponRepository;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveProduct;
+import com.backend.sunpick.domain.exclusive.entity.ExclusiveSaleEvent;
+import com.backend.sunpick.domain.exclusive.repository.ExclusiveProductRepository;
+import com.backend.sunpick.domain.exclusive.repository.ExclusiveSaleEventRepository;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.domain.point.entity.SunpickPointHistory;
+import com.backend.sunpick.domain.point.repository.SunpickPointHistoryRepository;
+import com.backend.sunpick.domain.purchase.entity.PurchaseHistory;
+import com.backend.sunpick.domain.purchase.enums.PurchaseType;
+import com.backend.sunpick.domain.purchase.repository.PurchaseHistoryRepository;
+import com.backend.sunpick.domain.store.entity.Store;
+import com.backend.sunpick.domain.store.repository.StoreRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class PurchaseHistoryJpaMappingTest {
+
+    @Autowired
+    private PurchaseHistoryRepository purchaseHistoryRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CouponIssuerRepository issuerRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private ExclusiveProductRepository productRepository;
+
+    @Autowired
+    private ExclusiveSaleEventRepository saleEventRepository;
+
+    @Autowired
+    private SunpickPointHistoryRepository pointHistoryRepository;
+
+    @Test
+    void 결제내역_엔티티_필드_및_연관관계_정상작동_테스트() {
+
+        // given
+        Member savedMember = memberRepository.save(TestEntityFactory.testMember());
+        CouponIssuer savedCouponIssuer = issuerRepository.save(
+            TestEntityFactory.testCouponIssuer());
+
+        Coupon savedCoupon = couponRepository.save(TestEntityFactory.testCoupon(savedCouponIssuer));
+        Store savedStore = storeRepository.save(TestEntityFactory.testStore(savedMember));
+
+        ExclusiveProduct savedExclusiveProduct = productRepository.save(
+            TestEntityFactory.testExclusiveProduct(savedStore));
+        ExclusiveSaleEvent savedExclusiveSaleEvent = saleEventRepository.save(
+            TestEntityFactory.testExclusiveSaleEvent(savedStore, savedExclusiveProduct));
+
+        SunpickPointHistory savedSunpickPointHistory = pointHistoryRepository.save(
+            TestEntityFactory.testSunpickPointHistory(savedMember));
+
+        PurchaseHistory purchaseHistory = TestEntityFactory.testPurchaseHistory(savedMember,
+            savedCoupon, savedExclusiveSaleEvent, savedSunpickPointHistory);
+
+        PurchaseHistory savedPurchaseHistory = purchaseHistoryRepository.save(purchaseHistory);
+        em.flush();
+        em.clear();
+
+        // when
+        PurchaseHistory selectedPurchaseHistory = purchaseHistoryRepository.findById(
+            savedPurchaseHistory.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedPurchaseHistory.getMember().getId())
+                .isEqualTo(savedMember.getId());
+            as.assertThat(selectedPurchaseHistory.getCoupon().getId())
+                .isEqualTo(savedCoupon.getId());
+            as.assertThat(selectedPurchaseHistory.getExclusiveSaleEvent().getExclusiveProduct()
+                .getId()).isEqualTo(savedExclusiveProduct.getId());
+            as.assertThat(selectedPurchaseHistory.getSunpickPointHistory().getId())
+                .isEqualTo(savedSunpickPointHistory.getId());
+            as.assertThat(selectedPurchaseHistory.getPrice()).isEqualTo(20000);
+            as.assertThat(selectedPurchaseHistory.getPurchaseType())
+                .isEqualTo(PurchaseType.CARD);
+        });
+    }
+}

--- a/sunpick/src/test/java/com/backend/sunpick/store/StoreJpaMappingTest.java
+++ b/sunpick/src/test/java/com/backend/sunpick/store/StoreJpaMappingTest.java
@@ -1,0 +1,60 @@
+package com.backend.sunpick.store;
+
+import com.backend.sunpick.config.JpaConfig;
+import com.backend.sunpick.domain.member.entity.Member;
+import com.backend.sunpick.domain.member.repository.MemberRepository;
+import com.backend.sunpick.domain.store.entity.Store;
+import com.backend.sunpick.domain.store.repository.StoreRepository;
+import com.backend.sunpick.factory.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+public class StoreJpaMappingTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 상점_엔티티_필드_및_연관관계_매핑_정상작동_테스트() {
+
+        // given
+        Member member = TestEntityFactory.testMember();
+        Member savedMember = memberRepository.save(member);
+
+        Store store = TestEntityFactory.testStore(savedMember);
+        Store savedStore = storeRepository.save(store);
+        em.flush();
+        em.clear();
+
+        // when
+        Store selectedStore = storeRepository.findById(savedStore.getId()).orElseThrow();
+
+        // then
+        assertSoftly(as -> {
+            as.assertThat(selectedStore.getMember().getId()).isEqualTo(savedMember.getId());
+            as.assertThat(selectedStore.getName()).isEqualTo("선픽마켓");
+            as.assertThat(selectedStore.getDescription()).isEqualTo("선픽마켓에 오신것을 환영합니다");
+            as.assertThat(selectedStore.getOwnerName()).isEqualTo("이영석");
+            as.assertThat(selectedStore.getCreatedAt()).isNotNull();
+            as.assertThat(selectedStore.getModifiedAt()).isNotNull();
+        });
+    }
+}

--- a/sunpick/src/test/resources/application-test.yaml
+++ b/sunpick/src/test/resources/application-test.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: sunpick
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/sunpick_test_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+    username: root
+    password: 9908
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+logging:
+  level:
+    org.hibernate.SQL: off
+    org.hibernate.type.descriptor.sql.BasicBinder: off


### PR DESCRIPTION
<!-- PR 제목: -->
<!-- [feat] Member 엔티티 및 회원가입 기능 구현 -->

## 🗂️ 작업 개요
- **Entity 클래스 작성에 대해 테스트 검증**
- Junit 기반 테스트 코드 작성
- `@DataJpaTest`를 활용한 빠른 JPA 테스트

## 🛠️ 주요 변경 사항
- 도메인별 엔티티 테스트 코드 작성
- 테스트용 DB 커넥션 `application.yaml` 작성

## 🧪 테스트
- `coupon` 도메인 엔티티 테스트 통과
- `exclusive` 도메인 엔티티 테스트 통과
- `member` 도메인 엔티티 테스트 통과
- `point` 도메인 엔티티 테스트 통과
- `purchase` 도메인 엔티티 테스트 통과
- `store` 도메인 엔티티 테스트 통과

## 📌 참고 사항
**EntityManager**의 `flush(), clear()`를 호출하여 테스트간 캐시사용을 방지했습니다.
