### PR TITLE
[feat] global exception 구현

### DIFF
--- a/sunpick/src/main/java/com/backend/sunpick/global/exception/GlobalExceptionHandler.java
+++ b/sunpick/src/main/java/com/backend/sunpick/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,78 @@
+package com.backend.sunpick.global.exception;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private String messageOrDefault(String message, String defaultMessage) {
+        if (message == null || message.isBlank()) {
+            return defaultMessage;
+        }
+        return message;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(messageOrDefault(e.getMessage(), "잘못된 요청입니다."));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        Optional<String> fieldMsg = e.getBindingResult().getFieldErrors().stream()
+            .map(fe -> fe.getField() + ": " + messageOrDefault(fe.getDefaultMessage(), "유효성 검증 오류"))
+            .findFirst();
+
+        Optional<String> globalMsg = e.getBindingResult().getGlobalErrors().stream()
+            .map(ge -> messageOrDefault(ge.getDefaultMessage(), "유효성 검증 오류"))
+            .findFirst();
+
+        String errorMessage = fieldMsg
+            .or(() -> globalMsg)  // fieldMsg -> globalMsg -> default
+            .orElse("요청 값 검증에 실패했습니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNoSuchElement(NoSuchElementException e) {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(messageOrDefault(e.getMessage(), "요청한 리소스를 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalState(IllegalStateException e) {
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(messageOrDefault(e.getMessage(), "잘못된 상태로 요청을 처리할 수 없습니다."));
+    }
+
+    @ExceptionHandler({
+        AccessDeniedException.class,
+        AuthorizationDeniedException.class,
+        SecurityException.class
+    })
+    public ResponseEntity<String> handleAccessDenied(Exception e) {
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(messageOrDefault(e.getMessage(), "접근 권한이 없습니다."));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(messageOrDefault(e.getMessage(), "서버 에러가 발생했습니다."));
+    }
+}


### PR DESCRIPTION
<!-- PR 제목: -->
<!-- [feat] Member 엔티티 및 회원가입 기능 구현 -->

## 🗂️ 작업 개요
- Global Exception에 대한 예외처리 코드 작성

## 🛠️ 주요 변경 사항
- Global Exception에 대한 예외처리 코드 작성

## 🧪 테스트
- 표준 예외 사용으로 테스트 진행하지 않았습니다.

## 📌 참고 사항
- 추후에 기능이 추가될 경우 추가적인 예외처리가 필요해질 수 있습니다.
- 스프링부트에서 기본적으로 처리하는 예외에 대해서 처리하지 않았습니다.
